### PR TITLE
Fix delegate and showIndicator() visibility inside CariocaMenu class

### DIFF
--- a/carioca/Library/CariocaMenu.swift
+++ b/carioca/Library/CariocaMenu.swift
@@ -187,7 +187,7 @@ public class CariocaMenu : NSObject, UIGestureRecognizerDelegate {
     ///The datasource of the menu
     var dataSource:CariocaMenuDataSource
     ///The delegate of events
-    weak var delegate:CariocaMenuDelegate?
+    public weak var delegate:CariocaMenuDelegate?
     /// The type of boomerang for the menu. Default : None
     public var boomerang:CariocaMenuBoomerangType
     

--- a/carioca/Library/CariocaMenu.swift
+++ b/carioca/Library/CariocaMenu.swift
@@ -622,7 +622,7 @@ public class CariocaMenu : NSObject, UIGestureRecognizerDelegate {
             - position: Top, Center or Bottom
             - offset: A random offset value. Should be negative when position is equal to `.Bottom`
     */
-    func showIndicator(edge:CariocaMenuEdge, position:CariocaMenuIndicatorViewPosition, offset:CGFloat){
+    public func showIndicator(edge:CariocaMenuEdge, position:CariocaMenuIndicatorViewPosition, offset:CGFloat){
         indicatorOffset = getIndicatorForEdge(edge).showAt(position, offset: offset)
         NSUserDefaults.standardUserDefaults().setDouble(Double(indicatorOffset), forKey: CariocaMenuUserDefaultsBoomerangVerticalKey)
         NSUserDefaults.standardUserDefaults().setValue(edge.rawValue, forKey: CariocaMenuUserDefaultsBoomerangHorizontalKey)


### PR DESCRIPTION
1. Make a delegate in CariocaMenu class to be public to make it possible to set a delegate outside of the demo project, i.e. in a user's app utilizing this POD.
2. Make CariocaMenu.showIndicator() method public to make it possible to initialize the initial position and style of the indicator in a user's app utilizing this POD.
