### PR TITLE
Make moveToTop method public to make it possible to use it outside of this module

### DIFF
--- a/carioca/Library/CariocaMenu.swift
+++ b/carioca/Library/CariocaMenu.swift
@@ -426,7 +426,7 @@ public class CariocaMenu : NSObject, UIGestureRecognizerDelegate {
     }
     
     ///Makes sure the containerView is on top of the hostView
-    func moveToTop() {
+    public func moveToTop() {
         hostView?.bringSubviewToFront(containerView)
         if gestureHelperViewLeft != nil{
             hostView?.bringSubviewToFront(gestureHelperViewLeft)


### PR DESCRIPTION
Very useful feature if you dynamically add views into your ViewController which requires menu to be put on top in the end.
