### PR TITLE
.left .right active menu state collision fix

### DIFF
--- a/carioca/Library/CariocaMenu.swift
+++ b/carioca/Library/CariocaMenu.swift
@@ -479,7 +479,6 @@ open class CariocaMenu : NSObject, UIGestureRecognizerDelegate {
                 let offsetSaved = CariocaMenu.getBoomerangVerticalValue()
                 otherIndicator.updateY(offsetSaved)
                 otherIndicator.show()
-                self.openingEdge = edgeToCheckAfterFirstAnimation
             }
         })
 


### PR DESCRIPTION
collision is easy to detect when having
cariocaMenu?.boomerang = .verticalAndHorizontal

and while in app using menu:
1. Swipe from right to open menu -> menu appears on the .left as expected
2. Then swipe from left to open menu -> menu appears on the .right as expected
3. Then swipe from the right again to open menu -> menu appears on the .right again which is WRONG. 
Expected behavior: menu should appear on the .left -> same as in step 1.

Collision was happening due to check in ```hideMenu()``` which was setting ```openingEdge``` property which was already set before in ```gestureTouched()``` -> which makes next time when ```gestureTouched()``` gets fired again -> the menu view's state is not being updated to correct one cuz ```openingEdge``` always equals to .right and ```newEdge``` also equals .right in this scenario

