### PR TITLE
.left .right active menu state collision fix

### DIFF
--- a/carioca/Library/CariocaMenu.swift
+++ b/carioca/Library/CariocaMenu.swift
@@ -507,6 +507,7 @@ open class CariocaMenu : NSObject, UIGestureRecognizerDelegate {
                 self.gestureHelperViewLeft?.isHidden = false
                 self.gestureHelperViewRight?.isHidden = false
                 self.delegate?.cariocaMenuDidClose!(self)
+                self.dataSource.setCellIdentifierForEdge!((self.openingEdge == .left) ? "cellRight" : "cellLeft")
         })
     }
     


### PR DESCRIPTION
collision is easy to detect when having
cariocaMenu?.boomerang = .verticalAndHorizontal

and while in app using menu:

Swipe from right to open menu -> menu appears on the .left as expected
Then swipe from left to open menu -> menu appears on the .right as expected
Then swipe from the right again to open menu -> menu appears on the .right again which is WRONG.
Expected behavior: menu should appear on the .left -> same as in step 1.

Tested fix with all boomerang states and now it works fine with all of them.